### PR TITLE
fix /intl-es/ segment issue#6

### DIFF
--- a/src/components/Spotify/index.tsx
+++ b/src/components/Spotify/index.tsx
@@ -23,6 +23,8 @@ export const Spotify = ({
 }: SpotifyProps) => {
   const url = new URL(link);
   // https://open.spotify.com/track/1KFxcj3MZrpBGiGA8ZWriv?si=f024c3aa52294aa1
+  // Remove any additional path segments
+  url.pathname = url.pathname.replace(/\/intl-\w+\//, "/");
   return (
     <iframe
       title="Spotify Web Player"


### PR DESCRIPTION
Fixin issue #6 
https://github.com/ctjlewis/react-spotify-embed/issues/6

using regular expression to remove /intl-es/ from url path.

The url copied from Spotify contains an additional segment : /intl-es/ before the track info.
https://open.spotify.com/intl-es/track/5pcG9pIhfDfCoPCeChSuSu?si=b4a2284e5c814e78